### PR TITLE
added 2 links - "udacity advanced" and "androidhive" turorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A complete reference for android developers. Here you can find references about 
 - [Udacity Tutorials - Fundamentals](https://www.udacity.com/course/developing-android-apps--ud853) - Udacity Tutorial covering the core topics of Android Development.
 - [Udacity Tutorials - Advanced](https://www.udacity.com/course/advanced-android-app-development--ud855) - Udacity Tutorial covering advanced topics of Android Development.
 - [Vogella Tutorials](http://www.vogella.com/tutorials/android.html) - Very good tutorials by Lars Vogel.
+- [AndroidHive Tutorials](https://www.androidhive.info) - More than 200 highly organised turorials covering various important implementations.
 - [Android Examples](https://github.com/nisrulz/android-examples) - Andriod Examples.
 - [Learn RxJava](https://mindorks.com/course/learn-rxjava) - RxJava Tutorials.
 - [Learn RxJava In The Best Way](https://blog.mindorks.com/a-complete-guide-to-learn-rxjava-b55c0cea3631) - Learn RxJava.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ A complete reference for android developers. Here you can find references about 
 - [Google Code Lab](https://codelabs.developers.google.com/?cat=Android) - Google code lab.
 - [Android Development](https://developer.android.com/index.html) - Android Development complete guide from Google.
 - [Android Guides](https://github.com/codepath/android_guides) - Extensive Open-Source Guides for Android Developers.
-- [Udacity Tutorials](https://www.udacity.com/course/developing-android-apps--ud853) - Udacity Tutorials.
+- [Udacity Tutorials - Fundamentals](https://www.udacity.com/course/developing-android-apps--ud853) - Udacity Tutorial covering the core topics of Android Development.
+- [Udacity Tutorials - Advanced](https://www.udacity.com/course/advanced-android-app-development--ud855) - Udacity Tutorial covering advanced topics of Android Development.
 - [Vogella Tutorials](http://www.vogella.com/tutorials/android.html) - Very good tutorials by Lars Vogel.
 - [Android Examples](https://github.com/nisrulz/android-examples) - Andriod Examples.
 - [Learn RxJava](https://mindorks.com/course/learn-rxjava) - RxJava Tutorials.


### PR DESCRIPTION
I have made 2 commits.

---
> **1. Added a "Udacity Tutorial" link to the list. The one tutorial that was already present was only part I of the 2 part series.**

- **Tutorial 1 - Fundamentals** (was already there)
This tutorials covers core topics like Activity Lifecycle, Intents, RecyclerView, Networking, Share Preferences, Databases, Content Providers, Architecture Components (Room, LiveData, ViewModel), Background Tasks, DataBinding, UI Polishing

- **Tutorial 2 - Advanced** (added this one)
This tutorial is a continuation of the first turorial and covers advanced concepts like : Fragments, Third-Party Libraries, Firebase Cloud Messaging, Google Play Services, Media Playback, App Widgets, Espresso (Unit & UI Testing), Publish the App.

---

> **2. Added "AndroidHive" Tutorial website to the list.**

This website has more than 200 highly organised, very good turorials covering various important topics and implementations that we need to do again and again.

**The Sections include**
- Beginer
- App Dev
- Database
- Architecture Components
- Cloud Connectivity
- Firebase
- Material Design
- UI & UX
---

Kindly look at the changes and share your thoughts!!